### PR TITLE
Adds iOS9 & 10 build support via Twilio Video 4.6

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/blackuy/react-native-twilio-video-web-rtc', tag: s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '11.0'
+  s.platform       = :ios, '10.0'
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 4.1'
+  s.dependency 'TwilioVideo', '~> 4.6'
 end


### PR DESCRIPTION
Note, this enables builds for iOS 9 & 10 but Twilio Video 4.6 does not support iOS 9 & 10